### PR TITLE
add custom option to hoodie.store method calls

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -37,6 +37,8 @@
       type = modelOrCollection.model.prototype.type;
     }
 
+    options.backbone = true;
+
     switch (method) {
     case 'read':
       if (id) {


### PR DESCRIPTION
so they can be distinguished from method calls coming from outside.

What I want is to do this:

``` js
var Collection = BaseCollection.extend({
  model: Model,

  initialize: function() {
    var type = this.model.prototype.type;
    Backbone.hoodie.store.on('change:'+type, _.bind(this.handleMeetingChange, this));
  },

  handleMeetingChange: function(eventType, object, options) {
    if (options.backbone) return;
    // update collection here
  }
});

makes sense?
```
