### PR TITLE
use .toJSON() to get attributes

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -37,6 +37,8 @@
       type = modelOrCollection.model.prototype.type;
     }
 
+    options.backbone = true;
+
     switch (method) {
     case 'read':
       if (id) {

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -30,7 +30,7 @@
     var attributes, id, promise, type;
 
     id = modelOrCollection.id;
-    attributes = modelOrCollection.attributes;
+    attributes = modelOrCollection.toJSON();
     type = modelOrCollection.type;
 
     if (! type) {

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -30,7 +30,7 @@
     var attributes, id, promise, type;
 
     id = modelOrCollection.id;
-    attributes = modelOrCollection.toJSON();
+    attributes = options.attrs || modelOrCollection.toJSON();
     type = modelOrCollection.type;
 
     if (! type) {


### PR DESCRIPTION
instead of 

``` js
attributes = modelOrCollection.attributes;
```

we should do

``` js
attributes = modelOrCollection.toJSON();
```

I often times hook into `toJSON` methods of models or collections to add properties that I want to be persisted but no overwritten. For example in relations, when I want to store `parentId` properties
