### PR TITLE
Use .toJSON() (& delete ._rev) rather than .changed

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -58,7 +58,9 @@
       });
       break;
     case 'update':
-      promise = Backbone.hoodie.store.updateOrAdd(type, id, modelOrCollection.changed, options)
+      var attributes = modelOrCollection.toJSON();
+      delete attributes._rev
+      promise = Backbone.hoodie.store.updateOrAdd(type, id, attributes, options)
       .done(function (attributes) {
         modelOrCollection.set(attributes);
       });


### PR DESCRIPTION
This works better for me than the change in #11, because for some reason in my case modelOrCollection.changed doesn't contain all (or sometimes any) of the changed attributes.
