### PR TITLE
Remove obsolete calls to set()

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -52,16 +52,10 @@
       }
       break;
     case 'create':
-      promise = Backbone.hoodie.store.add(type, attributes, options)
-      .done(function (attributes) {
-        modelOrCollection.set(attributes);
-      });
+      promise = Backbone.hoodie.store.add(type, attributes, options);
       break;
     case 'update':
-      promise = Backbone.hoodie.store.updateOrAdd(type, id, modelOrCollection.changed, options)
-      .done(function (attributes) {
-        modelOrCollection.set(attributes);
-      });
+      promise = Backbone.hoodie.store.updateOrAdd(type, id, modelOrCollection.changed, options);
       break;
     case 'delete':
       promise = Backbone.hoodie.store.remove(type, id, options);

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -11,10 +11,30 @@ describe('Backbone.Model', function () {
       type: 'task'
     });
 
-    this.testAttributes = {
-      id: 'juyc3ej',
+    // a fresh task
+    this.newTaskAttributes = {
       name: 'New Task'
     };
+
+    // a persisted task
+    this.taskAttributes = _.extend({}, this.newTaskAttributes, {
+      id: 'juyc3ej',
+      type: 'todo',
+      createdBy: 'pe3vv6m',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+
+    // a changeset for a task
+    this.changedTaskAttributes = {
+      name: 'Updated Name',
+      tags: 'foo, bar, baz'
+    }
+
+    // a changed task that has been persisted
+    this.updatedTaskAttributes = _.extend({}, this.taskAttributes, this.changedTaskAttributes, {
+      updatedAt: new Date()
+    });
 
     this.sandbox = sinon.sandbox.create();
 
@@ -35,18 +55,12 @@ describe('Backbone.Model', function () {
     });
 
     it('calls Backbone.Model.prototype.set with the given attributes and the remote option', function() {
-      var task = new this.Task(this.testAttributes);
+      var task = new this.Task(this.taskAttributes);
       var spy = this.sandbox.spy(task, 'set');
 
-      task.merge({
-        name: 'Updated Name',
-        tags: 'foo, bar, baz'
-      });
+      task.merge(this.changedTaskAttributes);
 
-      expect(spy).to.have.been.calledWith({
-        name: 'Updated Name',
-        tags: 'foo, bar, baz'
-      }, {
+      expect(spy).to.have.been.calledWith(this.changedTaskAttributes, {
         remote: true
       });
     });
@@ -60,7 +74,7 @@ describe('Backbone.Model', function () {
         this.spyOnSuccess = sinon.spy();
         this.spyOnError = sinon.spy();
 
-        this.task = new this.Task({ name: 'New Task' });
+        this.task = new this.Task(this.newTaskAttributes);
 
         this.task.save({}, {
           success: this.spyOnSuccess,
@@ -69,16 +83,16 @@ describe('Backbone.Model', function () {
       });
 
       it('delegates to Backbone.hoodie.store.add', function () {
-        expect(this.stub).to.have.been.calledWith('task', { name: 'New Task' });
+        expect(this.stub).to.have.been.calledWith('task', this.newTaskAttributes);
       });
 
       describe('success', function () {
         beforeEach(function () {
-          this.deferred.resolve(this.testAttributes);
+          this.deferred.resolve(this.taskAttributes);
         });
 
         it('updates the attributes', function () {
-          expect(this.task.attributes).to.deep.eql(this.testAttributes);
+          expect(this.task.attributes).to.deep.eql(this.taskAttributes);
         });
 
         it('calls the success callback', function () {
@@ -104,29 +118,25 @@ describe('Backbone.Model', function () {
         this.spyOnSuccess = sinon.spy();
         this.spyOnError = sinon.spy();
 
-        this.task = new this.Task(this.testAttributes);
+        this.task = new this.Task(this.taskAttributes);
 
-        this.task.save({
-          name: 'Updated Name'
-        }, {
+        this.task.save(this.changedTaskAttributes, {
           success: this.spyOnSuccess,
           error: this.spyOnError
         });
       });
 
       it('delegates to Backbone.hoodie.store.updateOrAdd with the changed attributes', function () {
-        expect(this.stub).to.have.been.calledWith('task', this.task.id, { name: 'Updated Name' });
+        expect(this.stub).to.have.been.calledWith('task', this.task.id, this.changedTaskAttributes);
       });
 
       describe('success', function () {
         beforeEach(function () {
-          this.updatedTestAttributes = this.testAttributes;
-          this.updatedTestAttributes.name = 'Updated Name';
-          this.deferred.resolve(this.updatedTestAttributes);
+          this.deferred.resolve(this.updatedTaskAttributes);
         });
 
         it('updates the attributes', function () {
-          expect(this.task.attributes).to.deep.eql(this.updatedTestAttributes);
+          expect(this.task.attributes).to.deep.eql(this.updatedTaskAttributes);
         });
 
         it('calls the success callback', function () {
@@ -153,7 +163,7 @@ describe('Backbone.Model', function () {
       this.spyOnSuccess = sinon.spy();
       this.spyOnError = sinon.spy();
 
-      this.task = new this.Task({ id: this.testAttributes.id } );
+      this.task = new this.Task({ id: this.taskAttributes.id } );
       this.task.fetch({
         success: this.spyOnSuccess,
         error: this.spyOnError
@@ -161,16 +171,16 @@ describe('Backbone.Model', function () {
     });
 
     it('delegates to Backbone.hoodie.store.find', function () {
-      expect(this.stub).to.have.been.calledWith('task', this.task.id);
+      expect(this.stub).to.have.been.calledWith('task', this.taskAttributes.id);
     });
 
     describe('success', function () {
       beforeEach(function () {
-        this.deferred.resolve(this.testAttributes);
+        this.deferred.resolve(this.taskAttributes);
       });
 
       it('updates the attributes', function () {
-        expect(this.task.attributes).to.deep.eql(this.testAttributes);
+        expect(this.task.attributes).to.deep.eql(this.taskAttributes);
       });
 
       it('calls the success callback', function () {
@@ -196,7 +206,7 @@ describe('Backbone.Model', function () {
       this.spyOnSuccess = sinon.spy();
       this.spyOnError = sinon.spy();
 
-      this.task = new this.Task(this.testAttributes);
+      this.task = new this.Task(this.taskAttributes);
       this.task.save();
 
       this.task.destroy({
@@ -206,7 +216,7 @@ describe('Backbone.Model', function () {
     });
 
     it('delegates to Backbone.hoodie.store.remove', function () {
-      expect(this.stub).to.have.been.calledWith('task', this.task.id);
+      expect(this.stub).to.have.been.calledWith('task', this.taskAttributes.id);
     });
 
     describe('success', function () {


### PR DESCRIPTION
As far as I can tell, `set()` is already called by Backbone in the success callbacks defined in `Backbone.Model.fetch`, `Backbone.Model.save`, `Backbone.Collection.fetch`.
