### PR TITLE
Initialize specs

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -90,31 +90,27 @@
     var self = this;
     var store;
 
-    if (! this.model) {
+    if (!this.model) {
       return;
     }
 
     type = this.model.prototype.type;
 
     if (type) {
-
       store = Backbone.hoodie.store(type);
-      store.on('add', function (attributes, options) {
-        var record;
 
-        // see https://github.com/hoodiehq/backbone-hoodie/issues/3
-        if (self.storeBindingFilter && !self.storeBindingFilter(attributes)) {
+      store.on('add', function (attributes, options) {
+        if (!options.remote) {
           return;
         }
 
-        record = self.add(attributes, options);
-        self.trigger('create', record, options);
+        self.add(attributes, options);
       });
 
       store.on('remove', function (attributes, options) {
         var record;
 
-        if (self.storeBindingFilter && !self.storeBindingFilter(attributes)) {
+        if (!options.remote) {
           return;
         }
 
@@ -127,16 +123,14 @@
       store.on('update', function (attributes, options) {
         var record;
 
-        if (self.storeBindingFilter && !self.storeBindingFilter(attributes)) {
+        if (!options.remote) {
           return;
         }
 
         record = self.get(attributes.id);
-        if (options.remote && record) {
+        if (record) {
           record.merge(attributes);
         }
-
-        self.trigger('update', record, options);
       });
     }
   };

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -94,7 +94,7 @@
       return;
     }
 
-    type = this.model.type;
+    type = this.model.prototype.type;
 
     if (type) {
 

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -5,7 +5,7 @@
 describe('Backbone.Collection', function () {
 
   beforeEach(function () {
-    Backbone.connect("http://example.com");
+    Backbone.connect('http://example.com');
 
     this.Task = Backbone.Model.extend({
       type: 'task'
@@ -34,10 +34,106 @@ describe('Backbone.Collection', function () {
   });
 
   describe('Backbone.Collection.prototype.initialize', function() {
-    it('initializes the hoodie store', function () {
-      var spy = this.sandbox.spy(Backbone.hoodie, 'store');
+    beforeEach(function () {
+      var events = {};
+      this.events = events;
+      this.stubStore = this.sandbox.stub(Backbone.hoodie, 'store', function () {
+        return {
+          on: function (event, callback) {
+            events[event] = callback;
+          }
+        };
+      });
+
       this.tasks = new this.Tasks();
-      expect(spy).to.have.been.calledWith('task');
+    });
+
+    it('initializes the hoodie store', function () {
+      expect(this.stubStore).to.have.been.calledWith('task');
+    });
+
+    describe('hoodie store event listeners', function () {
+      describe('add', function () {
+        beforeEach(function () {
+          this.addSpy = this.sandbox.spy(this.tasks, 'add');
+        });
+
+        describe('from remote', function () {
+          it('adds a new model to the collection', function () {
+            this.events.add(this.testAttributes, { remote: true });
+            expect(this.addSpy).to.have.been.calledWith(this.testAttributes, { remote: true });
+          });
+        });
+
+        describe('from the client', function () {
+          it('does not add the model to the collection again', function () {
+            this.events.add(this.testAttributes, { remote: false });
+            expect(this.addSpy).to.not.have.been.called;
+          });
+        });
+      });
+
+      describe('update', function () {
+        beforeEach(function () {
+          this.task = new this.Task(this.testAttributes);
+          this.setSpy = this.sandbox.spy(this.task, 'set');
+        });
+
+        describe('from remote', function () {
+          describe('when the model exists', function () {
+            it('updates the model', function () {
+              this.tasks.add(this.task);
+              this.events.update(this.testAttributes, { remote: true });
+              expect(this.setSpy).to.have.been.calledWith(this.testAttributes, { remote: true });
+            });
+          });
+
+          describe('when the model does not exist', function () {
+            it('it does not throw an exception', function () {
+              expect(this.events.update({ id: 'unknown' }, { remote: true })).to.not.throw;
+            });
+          });
+        });
+
+        describe('from the client', function () {
+          it('does not update the model again', function () {
+            this.tasks.add(this.task);
+            this.events.update(this.testAttributes, { remote: false });
+            expect(this.setSpy).to.not.have.been.called;
+          });
+        });
+      });
+
+      describe('remove', function () {
+        beforeEach(function () {
+          this.task = new this.Task(this.testAttributes);
+          this.destroySpy = this.sandbox.spy(this.task, 'destroy');
+        });
+
+        describe('from remote', function () {
+          describe('when the model exists', function () {
+            it('removes the model from the collection', function () {
+              this.tasks.add(this.task);
+              this.events.remove(this.testAttributes, { remote: true });
+              expect(this.destroySpy).to.have.been.called;
+            });
+          });
+
+          describe('when the model does not exist', function () {
+            it('it does not throw an exception', function () {
+              expect(this.events.remove({ id: 'unknown' }, { remote: true })).to.not.throw;
+            });
+          });
+        });
+
+        describe('from the client', function () {
+          it('does not add the model to the collection again', function () {
+            this.tasks.add(this.task);
+            this.events.remove(this.testAttributes, { remote: false });
+            expect(this.destroySpy).to.not.have.been.called;
+          });
+        });
+      });
     });
   });
 

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -33,6 +33,14 @@ describe('Backbone.Collection', function () {
     this.sandbox.restore();
   });
 
+  describe('Backbone.Collection.prototype.initialize', function() {
+    it('initializes the hoodie store', function () {
+      var spy = this.sandbox.spy(Backbone.hoodie, 'store');
+      this.tasks = new this.Tasks();
+      expect(spy).to.have.been.calledWith('task');
+    });
+  });
+
   describe('Backbone.Collection.prototype.create', function() {
     beforeEach(function () {
       this.stub = this.sandbox.stub(Backbone.hoodie.store, 'add', this.promiseMethodStub);


### PR DESCRIPTION
This Pull Request adds tests for the `hoodie.store` event handlers in `Backbone.Collection.initialize` and fixes some issues.

I have removed the checks for `self.storeBindingFilter` since this not implemented anywhere.

Instead all event handlers do a check for `options.remote` and the collection is only updated if `options.remote` is set. This ensures that the collection is not changed twice when an event is triggered by the client. This implies, that all client-side changes for a collection are made via Backbone.

I have removed the calls to `trigger('create')` and `trigger('update')`, since they do not have any effect. Or are these custom (non-Backbone) events triggered intentionally?

Apart form that, I have fixed an issue where the type of the collection was always `undefined`.
