### PR TITLE
Improve sync

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -104,7 +104,9 @@
           return;
         }
 
-        self.add(attributes);
+        self.add(attributes, {
+          hoodie: true
+        });
       });
 
       store.on('remove', function (attributes, options) {
@@ -131,7 +133,9 @@
 
         record = self.get(attributes.id);
         if (record) {
-          record.set(attributes);
+          record.set(attributes, {
+            hoodie: true
+          });
         }
       });
     }

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -105,6 +105,7 @@
         }
 
         self.add(attributes, {
+          remote: options.remote,
           hoodie: true
         });
       });
@@ -119,6 +120,7 @@
         record = self.get(attributes.id);
         if (record) {
           record.destroy({
+            remote: options.remote,
             hoodie: true
           });
         }
@@ -134,6 +136,7 @@
         record = self.get(attributes.id);
         if (record) {
           record.set(attributes, {
+            remote: options.remote,
             hoodie: true
           });
         }

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -35,6 +35,10 @@
 
     options = options || {};
 
+    if (options.hoodie) {
+      return;
+    }
+
     id = modelOrCollection.id;
     attributes = options.attrs || modelOrCollection.toJSON();
     type = modelOrCollection.type;
@@ -100,7 +104,7 @@
           return;
         }
 
-        self.add(attributes, options);
+        self.add(attributes);
       });
 
       store.on('remove', function (attributes, options) {
@@ -112,7 +116,9 @@
 
         record = self.get(attributes.id);
         if (record) {
-          record.destroy(options);
+          record.destroy({
+            hoodie: true
+          });
         }
       });
 
@@ -125,7 +131,7 @@
 
         record = self.get(attributes.id);
         if (record) {
-          record.set(attributes, options);
+          record.set(attributes);
         }
       });
     }

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -31,7 +31,7 @@
   };
 
   Backbone.sync = function (method, modelOrCollection, options) {
-    var attributes, id, promise, type;
+    var attributes, id, promise, type, storeOptions;
 
     options = options || {};
 
@@ -43,7 +43,9 @@
       type = modelOrCollection.model.prototype.type;
     }
 
-    options.backbone = true;
+    storeOptions = {
+      backbone: true
+    };
 
     switch (method) {
     case 'read':
@@ -58,13 +60,13 @@
       }
       break;
     case 'create':
-      promise = Backbone.hoodie.store.add(type, attributes, options);
+      promise = Backbone.hoodie.store.add(type, attributes, storeOptions);
       break;
     case 'update':
-      promise = Backbone.hoodie.store.updateOrAdd(type, id, modelOrCollection.changed, options);
+      promise = Backbone.hoodie.store.updateOrAdd(type, id, modelOrCollection.changed, storeOptions);
       break;
     case 'delete':
-      promise = Backbone.hoodie.store.remove(type, id, options);
+      promise = Backbone.hoodie.store.remove(type, id, storeOptions);
     }
 
     if (options.success) {
@@ -94,7 +96,7 @@
       store = Backbone.hoodie.store(type);
 
       store.on('add', function (attributes, options) {
-        if (!options.remote) {
+        if (options.backbone) {
           return;
         }
 
@@ -104,7 +106,7 @@
       store.on('remove', function (attributes, options) {
         var record;
 
-        if (!options.remote) {
+        if (options.backbone) {
           return;
         }
 
@@ -117,7 +119,7 @@
       store.on('update', function (attributes, options) {
         var record;
 
-        if (!options.remote) {
+        if (options.backbone) {
           return;
         }
 

--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -79,12 +79,6 @@
     return promise;
   };
 
-  Backbone.Model.prototype.merge = function (attributes) {
-    this.set(attributes, {
-      remote: true
-    });
-  };
-
   Backbone.Collection.prototype.initialize = function () {
     var type;
     var self = this;
@@ -129,7 +123,7 @@
 
         record = self.get(attributes.id);
         if (record) {
-          record.merge(attributes);
+          record.set(attributes, options);
         }
       });
     }

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -62,12 +62,16 @@ describe('Backbone.Collection', function () {
           beforeEach(function () {
             this.storeAddSpy = this.sandbox.spy(Backbone.hoodie.store, 'add');
 
-            this.events.add(this.testAttributes, { backbone: false });
+            this.events.add(this.testAttributes, {
+              backbone: false,
+              remote: true
+            });
           });
 
           it('adds a new model to the collection', function () {
             expect(this.addSpy).to.have.been.calledWith(this.testAttributes, {
-              hoodie: true
+              hoodie: true,
+              remote: true
             });
           });
 
@@ -96,12 +100,16 @@ describe('Backbone.Collection', function () {
               this.storeUpdateOrAddSpy = this.sandbox.spy(Backbone.hoodie.store, 'updateOrAdd');
 
               this.tasks.add(this.task);
-              this.events.update(this.testAttributes, { backbone: false });
+              this.events.update(this.testAttributes, {
+                backbone: false,
+                remote: true
+              });
             });
 
             it('updates the model', function () {
               expect(this.setSpy).to.have.been.calledWith(this.testAttributes, {
-                hoodie: true
+                hoodie: true,
+                remote: true
               });
             });
 
@@ -138,12 +146,16 @@ describe('Backbone.Collection', function () {
               this.storeRemoveSpy = this.sandbox.spy(Backbone.hoodie.store, 'remove');
 
               this.tasks.add(this.task);
-              this.events.remove(this.testAttributes, { backbone: false });
+              this.events.remove(this.testAttributes, {
+                backbone: false,
+                remote: true
+              });
             });
 
             it('removes the model from the collection', function () {
               expect(this.destroySpy).to.have.been.calledWith({
-                hoodie: true
+                hoodie: true,
+                remote: true
               });
             });
 

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -59,9 +59,18 @@ describe('Backbone.Collection', function () {
         });
 
         describe('triggered outside of backbone', function () {
-          it('adds a new model to the collection', function () {
+          beforeEach(function () {
+            this.storeAddSpy = this.sandbox.spy(Backbone.hoodie.store, 'add');
+
             this.events.add(this.testAttributes, { backbone: false });
-            expect(this.addSpy).to.have.been.calledWith(this.testAttributes, { backbone: false });
+          });
+
+          it('adds a new model to the collection', function () {
+            expect(this.addSpy).to.have.been.calledWith(this.testAttributes);
+          });
+
+          it('does not delegate to the store again', function () {
+            expect(this.storeAddSpy).to.not.have.been.called;
           });
         });
 
@@ -81,10 +90,19 @@ describe('Backbone.Collection', function () {
 
         describe('triggered outside of backbone', function () {
           describe('when the model exists', function () {
-            it('updates the model', function () {
+            beforeEach(function () {
+              this.storeUpdateOrAddSpy = this.sandbox.spy(Backbone.hoodie.store, 'updateOrAdd');
+
               this.tasks.add(this.task);
               this.events.update(this.testAttributes, { backbone: false });
-              expect(this.setSpy).to.have.been.calledWith(this.testAttributes, { backbone: false });
+            });
+
+            it('updates the model', function () {
+              expect(this.setSpy).to.have.been.calledWith(this.testAttributes);
+            });
+
+            it('does not delegate to the store again', function () {
+              expect(this.storeUpdateOrAddSpy).to.not.have.been.called;
             });
           });
 
@@ -112,10 +130,19 @@ describe('Backbone.Collection', function () {
 
         describe('triggered outside of backbone', function () {
           describe('when the model exists', function () {
-            it('removes the model from the collection', function () {
+            beforeEach(function () {
+              this.storeRemoveSpy = this.sandbox.spy(Backbone.hoodie.store, 'remove');
+
               this.tasks.add(this.task);
               this.events.remove(this.testAttributes, { backbone: false });
+            });
+
+            it('removes the model from the collection', function () {
               expect(this.destroySpy).to.have.been.called;
+            });
+
+            it('does not delegate to the store again', function () {
+              expect(this.storeRemoveSpy).to.not.have.been.called;
             });
           });
 

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -58,16 +58,16 @@ describe('Backbone.Collection', function () {
           this.addSpy = this.sandbox.spy(this.tasks, 'add');
         });
 
-        describe('from remote', function () {
+        describe('triggered outside of backbone', function () {
           it('adds a new model to the collection', function () {
-            this.events.add(this.testAttributes, { remote: true });
-            expect(this.addSpy).to.have.been.calledWith(this.testAttributes, { remote: true });
+            this.events.add(this.testAttributes, { backbone: false });
+            expect(this.addSpy).to.have.been.calledWith(this.testAttributes, { backbone: false });
           });
         });
 
-        describe('from the client', function () {
+        describe('triggered from backbone', function () {
           it('does not add the model to the collection again', function () {
-            this.events.add(this.testAttributes, { remote: false });
+            this.events.add(this.testAttributes, { backbone: true });
             expect(this.addSpy).to.not.have.been.called;
           });
         });
@@ -79,26 +79,26 @@ describe('Backbone.Collection', function () {
           this.setSpy = this.sandbox.spy(this.task, 'set');
         });
 
-        describe('from remote', function () {
+        describe('triggered outside of backbone', function () {
           describe('when the model exists', function () {
             it('updates the model', function () {
               this.tasks.add(this.task);
-              this.events.update(this.testAttributes, { remote: true });
-              expect(this.setSpy).to.have.been.calledWith(this.testAttributes, { remote: true });
+              this.events.update(this.testAttributes, { backbone: false });
+              expect(this.setSpy).to.have.been.calledWith(this.testAttributes, { backbone: false });
             });
           });
 
           describe('when the model does not exist', function () {
             it('it does not throw an exception', function () {
-              expect(this.events.update({ id: 'unknown' }, { remote: true })).to.not.throw;
+              expect(this.events.update({ id: 'unknown' }, { backbone: false })).to.not.throw;
             });
           });
         });
 
-        describe('from the client', function () {
+        describe('triggered from backbone', function () {
           it('does not update the model again', function () {
             this.tasks.add(this.task);
-            this.events.update(this.testAttributes, { remote: false });
+            this.events.update(this.testAttributes, { backbone: true });
             expect(this.setSpy).to.not.have.been.called;
           });
         });
@@ -110,26 +110,26 @@ describe('Backbone.Collection', function () {
           this.destroySpy = this.sandbox.spy(this.task, 'destroy');
         });
 
-        describe('from remote', function () {
+        describe('triggered outside of backbone', function () {
           describe('when the model exists', function () {
             it('removes the model from the collection', function () {
               this.tasks.add(this.task);
-              this.events.remove(this.testAttributes, { remote: true });
+              this.events.remove(this.testAttributes, { backbone: false });
               expect(this.destroySpy).to.have.been.called;
             });
           });
 
           describe('when the model does not exist', function () {
             it('it does not throw an exception', function () {
-              expect(this.events.remove({ id: 'unknown' }, { remote: true })).to.not.throw;
+              expect(this.events.remove({ id: 'unknown' }, { backbone: false })).to.not.throw;
             });
           });
         });
 
-        describe('from the client', function () {
+        describe('triggered from backbone', function () {
           it('does not add the model to the collection again', function () {
             this.tasks.add(this.task);
-            this.events.remove(this.testAttributes, { remote: false });
+            this.events.remove(this.testAttributes, { backbone: true });
             expect(this.destroySpy).to.not.have.been.called;
           });
         });

--- a/test/specs/collection.spec.js
+++ b/test/specs/collection.spec.js
@@ -66,7 +66,9 @@ describe('Backbone.Collection', function () {
           });
 
           it('adds a new model to the collection', function () {
-            expect(this.addSpy).to.have.been.calledWith(this.testAttributes);
+            expect(this.addSpy).to.have.been.calledWith(this.testAttributes, {
+              hoodie: true
+            });
           });
 
           it('does not delegate to the store again', function () {
@@ -98,7 +100,9 @@ describe('Backbone.Collection', function () {
             });
 
             it('updates the model', function () {
-              expect(this.setSpy).to.have.been.calledWith(this.testAttributes);
+              expect(this.setSpy).to.have.been.calledWith(this.testAttributes, {
+                hoodie: true
+              });
             });
 
             it('does not delegate to the store again', function () {
@@ -138,7 +142,9 @@ describe('Backbone.Collection', function () {
             });
 
             it('removes the model from the collection', function () {
-              expect(this.destroySpy).to.have.been.called;
+              expect(this.destroySpy).to.have.been.calledWith({
+                hoodie: true
+              });
             });
 
             it('does not delegate to the store again', function () {

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -49,23 +49,6 @@ describe('Backbone.Model', function () {
     this.sandbox.restore();
   });
 
-  describe('Backbone.Model.prototype.merge', function() {
-    it('defines Backbone.Model.prototype.merge', function() {
-      expect(Backbone.Model.prototype.merge).to.be.an.instanceof(Function);
-    });
-
-    it('calls Backbone.Model.prototype.set with the given attributes and the remote option', function() {
-      var task = new this.Task(this.taskAttributes);
-      var spy = this.sandbox.spy(task, 'set');
-
-      task.merge(this.changedTaskAttributes);
-
-      expect(spy).to.have.been.calledWith(this.changedTaskAttributes, {
-        remote: true
-      });
-    });
-  });
-
   describe('Backbone.Model.prototype.save', function() {
     describe('for a new model', function() {
       beforeEach(function () {

--- a/test/specs/model.spec.js
+++ b/test/specs/model.spec.js
@@ -66,7 +66,7 @@ describe('Backbone.Model', function () {
       });
 
       it('delegates to Backbone.hoodie.store.add', function () {
-        expect(this.stub).to.have.been.calledWith('task', this.newTaskAttributes);
+        expect(this.stub).to.have.been.calledWith('task', this.newTaskAttributes, { backbone: true });
       });
 
       describe('success', function () {
@@ -110,7 +110,7 @@ describe('Backbone.Model', function () {
       });
 
       it('delegates to Backbone.hoodie.store.updateOrAdd with the changed attributes', function () {
-        expect(this.stub).to.have.been.calledWith('task', this.task.id, this.changedTaskAttributes);
+        expect(this.stub).to.have.been.calledWith('task', this.task.id, this.changedTaskAttributes, { backbone: true });
       });
 
       describe('success', function () {
@@ -199,7 +199,7 @@ describe('Backbone.Model', function () {
     });
 
     it('delegates to Backbone.hoodie.store.remove', function () {
-      expect(this.stub).to.have.been.calledWith('task', this.taskAttributes.id);
+      expect(this.stub).to.have.been.calledWith('task', this.taskAttributes.id, { backbone: true });
     });
 
     describe('success', function () {


### PR DESCRIPTION
This PR improves the synchronization.

Instead of checking for `options.remote`, the event handlers for the hoodie store check for `options.backbone`.
If the change originates from Backbone it is ignored, otherwise the collection is updated.

That way, client-side changes to the hoodie store that are made outside of Backbone (e.g. directly via `hoodie.store.add('task', { name: 'new task'})`) will also be reflected in the collection. Previously only remote changes to the hoodie store were picked up.

Apart from that `Backbone.Model.prototype.merge` has been removed and `set()` is called directly. 
`Backbone.Model.prototype.set` already takes care of only updating changed attributes.

The hoodie store methods will only get a specific set of `storeOptions`, instead of all the options that were passed to `Backbone.prototype.sync`.
