### PR TITLE
Backbone.sync options are optional

### DIFF
--- a/src/backbone-hoodie.js
+++ b/src/backbone-hoodie.js
@@ -33,6 +33,8 @@
   Backbone.sync = function (method, modelOrCollection, options) {
     var attributes, id, promise, type;
 
+    options = options || {};
+
     id = modelOrCollection.id;
     attributes = options.attrs || modelOrCollection.toJSON();
     type = modelOrCollection.type;

--- a/test/specs/backbone.spec.js
+++ b/test/specs/backbone.spec.js
@@ -4,23 +4,48 @@
 'use strict';
 
 describe('Backbone', function() {
-  beforeEach(function () {
+  beforeEach(function() {
     this.url = 'http://example.com';
+    this.sandbox = sinon.sandbox.create();
   });
 
-  it('defines Backbone.connect', function() {
-    expect(Backbone.connect).to.be.an.instanceof(Function);
+  afterEach(function() {
+    this.sandbox.restore();
   });
 
-  it('initializes Hoodie with the given URL', function() {
-    Backbone.connect(this.url);
-    expect(Backbone.hoodie).to.be.an.instanceof(Hoodie);
-    expect(Backbone.hoodie.baseUrl).to.eql(this.url);
+  describe('Backbone.connect', function() {
+    it('defines Backbone.connect', function() {
+      expect(Backbone.connect).to.be.an.instanceof(Function);
+    });
+
+    it('initializes Hoodie with the given URL', function() {
+      Backbone.connect(this.url);
+      expect(Backbone.hoodie).to.be.an.instanceof(Hoodie);
+      expect(Backbone.hoodie.baseUrl).to.eql(this.url);
+    });
+
+    it('initializes with an existing Hoodie instance', function() {
+      var hoodie  = new Hoodie(this.url);
+      Backbone.connect(hoodie);
+      expect(Backbone.hoodie).to.eql(hoodie);
+    });
   });
 
-  it('initializes with an existing Hoodie instance', function() {
-    var hoodie  = new Hoodie(this.url);
-    Backbone.connect(hoodie);
-    expect(Backbone.hoodie).to.eql(hoodie);
+  describe('Backbone.sync', function() {
+    beforeEach(function() {
+      Backbone.connect(this.url);
+      var Task = Backbone.Model.extend({
+        type: 'task'
+      });
+      this.task = new Task({ id: 'juyc3ej' });
+    });
+
+    it('accepts options', function() {
+      expect(Backbone.sync('create', this.task, { silent: true })).to.be.ok;
+    });
+
+    it('does not require options', function() {
+      expect(Backbone.sync('create', this.task)).to.be.ok;
+    });
   });
 });


### PR DESCRIPTION
Just a small change that ensures that `options` are optional, in alignment to the original signature of `Backbone.sync`.
